### PR TITLE
Write Matrix Succeed Using Stack instead of Heap

### DIFF
--- a/Projects/proj2_summer2023/src/write_matrix.s
+++ b/Projects/proj2_summer2023/src/write_matrix.s
@@ -25,13 +25,12 @@
 write_matrix:
 
     # Prologue
-    addi sp, sp, -24
+    addi sp, sp, -20
     sw ra, 0(sp)
     sw s0, 4(sp)
     sw s1, 8(sp)
     sw s2, 12(sp)
     sw s3, 16(sp)
-    sw s4, 20(sp)
 
     mv s0, a0
     mv s1, a1
@@ -47,20 +46,20 @@ write_matrix:
     mv s0, a0           # Now s0 stores the file descriptor
 
     # Write the number of rows and cols into the file
-    li a0, 8
-    jal ra, malloc
-    beq a0, zero, malloc_failed
-    mv s4, a0           # Now s4 is used to store the numbers into the memory
-    sw s2, 0(s4)
-    sw s3, 4(s4)
+    addi sp, sp, -8
+    sw s2, 0(sp)
+    sw s3, 4(sp)
 
     mv a0, s0
-    mv a1, s4
+    mv a1, sp
     li a2, 2
     li a3, 4
     jal ra, fwrite
     li t0, 2
     bne a0, t0, fwrite_failed
+
+    # Restore sp
+    addi sp, sp, 8
 
     # Write the matrix into the file
     mul s2, s2, s3
@@ -76,18 +75,13 @@ write_matrix:
     jal ra, fclose
     bnez a0, fclose_failed
 
-    # Free the memory which is allocated before
-    mv a0, s4
-    jal ra, free
-
     # Epilogue
     lw ra, 0(sp)
     lw s0, 4(sp)
     lw s1, 8(sp)
     lw s2, 12(sp)
     lw s3, 16(sp)
-    lw s4, 20(sp)
-    addi sp, sp, 24
+    addi sp, sp, 20
 
     jr ra
 


### PR DESCRIPTION
Instead of `malloc` 8 bytes of space in the heap, I choose to use stack to store these two integers(rows and cols) because malloc is expensive. And this works!